### PR TITLE
Feat/add hide remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@
 *webdriver-image-comparison* is an image compare module that can be used for different NodeJS Test automation frameworks that support the webdriver protocol.
 
 More information and documentation will soon come
+
+## TO-DO
+- [ ] Make proper documentation
+- [ ] Optimize UT's and increase coverage
+- [ ] Look at the execute methods, maybe they could be optimized

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -126,6 +126,18 @@ and reset when done
 
 Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot 
 
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements.
+
 #### `resizeDimensions`
 - **Type:** `object`
 - **Mandatory:** no
@@ -147,7 +159,19 @@ and reset when done
 - **Mandatory:** No
 - **Default:** `false`
 
-Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot 
+Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot
+
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements. 
 
 ### `saveFullPageScreen`
 #### `disableCSSAnimation`
@@ -170,7 +194,26 @@ The timeout in milliseconds to wait after a scroll. This might help identifying 
 - **Mandatory:** No
 - **Default:** `false`
 
-Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot 
+Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot
+
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements.
+
+#### `hideAfterFirstScroll`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods will hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+This will be handy when a page for example holds sticky elements that will scroll with the page if the page is scrolled but will give an anoying effect when a fullpage screenshot is made 
 
 ### `checkElement`
 #### `blockOut`
@@ -194,7 +237,19 @@ and reset when done
 - **Mandatory:** No
 - **Default:** `false`
 
-Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot 
+Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot
+
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements. 
 
 #### `resizeDimensions`
 - **Type:** `object`
@@ -228,7 +283,19 @@ and reset when done
 - **Mandatory:** No
 - **Default:** `false`
 
-Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot  
+Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot
+
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements.  
 
 ### `checkScreen` compare options 
 The compare options can be set as `checkScreen` options, see [Compare options](./OPTIONS.md#compare-options)
@@ -262,7 +329,26 @@ The timeout in milliseconds to wait after a scroll. This might help identifying 
 - **Mandatory:** No
 - **Default:** `false`
 
-Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot  
+Hide scrollbars in the application. If set to true all scrollbars will be disabled before taking a screenshot
+
+#### `hideElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+
+#### `removeElements`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods can *remove* 1 or multiple elements by adding the property `display: none` to them by providing an array of elements.
+
+#### `hideAfterFirstScroll`
+- **Type:** `array`
+- **Mandatory:** no
+
+This methods will hide 1 or multiple elements by adding the property `visibility: hidden` to them by providing an array of elements.
+This will be handy when a page for example holds sticky elements that will scroll with the page if the page is scrolled but will give an anoying effect when a fullpage screenshot is made  
 
 ### `checkFullPageScreen` compare options 
 The compare options can be set as `checkFullPageScreen` options, see [Compare options](./OPTIONS.md#compare-options)

--- a/lib/clientSideScripts/__snapshots__/hideRemoveElements.spec.ts.snap
+++ b/lib/clientSideScripts/__snapshots__/hideRemoveElements.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 1`] = `""`;
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 2`] = `""`;
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 3`] = `"hidden"`;
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 4`] = `"hidden"`;
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 5`] = `""`;
+
+exports[`hideRemoveElements should be able to hide elements and put them back again 6`] = `""`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 1`] = `""`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 2`] = `""`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 3`] = `"none"`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 4`] = `"none"`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 5`] = `""`;
+
+exports[`hideRemoveElements should be able to remove elements and put them back again 6`] = `""`;

--- a/lib/clientSideScripts/hideRemoveElements.spec.ts
+++ b/lib/clientSideScripts/hideRemoveElements.spec.ts
@@ -1,0 +1,79 @@
+import hideRemoveElements from './hideRemoveElements';
+
+describe('hideRemoveElements', () => {
+  it('should be able to hide elements and put them back again', () => {
+    document.body.innerHTML =
+      '<div>' +
+      '   <span id="id-1">Hello</span>' +
+      '   <span id="id-2">Hello</span>' +
+      '   <div>' +
+      '     <span id="id-3">Hello</span>' +
+      '     <span id="id-4">Hello</span>' +
+      '  </div>' +
+      '</div>';
+
+    // Check not hidden
+    expect((<HTMLElement>document.querySelector('#id-1')).style.visibility).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-3')).style.visibility).toMatchSnapshot();
+
+    hideRemoveElements({
+        hide: [document.querySelector('#id-1'), document.querySelector('#id-3')],
+        remove: [],
+      },
+      true,
+    );
+
+    // Check hidden
+    expect((<HTMLElement>document.querySelector('#id-1')).style.visibility).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-3')).style.visibility).toMatchSnapshot();
+
+    hideRemoveElements({
+        hide: [document.querySelector('#id-1'), document.querySelector('#id-3')],
+        remove: [],
+      },
+      false,
+    );
+
+    // Check not hidden
+    expect((<HTMLElement>document.querySelector('#id-1')).style.visibility).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-3')).style.visibility).toMatchSnapshot();
+  });
+
+  it('should be able to remove elements and put them back again', () => {
+    document.body.innerHTML =
+      '<div>' +
+      '   <span id="id-1">Hello</span>' +
+      '   <span id="id-2">Hello</span>' +
+      '   <div>' +
+      '     <span id="id-3">Hello</span>' +
+      '     <span id="id-4">Hello</span>' +
+      '  </div>' +
+      '</div>';
+
+    // Check not removed
+    expect((<HTMLElement>document.querySelector('#id-2')).style.display).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-4')).style.display).toMatchSnapshot();
+
+    hideRemoveElements({
+        hide: [],
+        remove: [document.querySelector('#id-2'), document.querySelector('#id-4')],
+      },
+      true,
+    );
+
+    // Check removed
+    expect((<HTMLElement>document.querySelector('#id-2')).style.display).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-4')).style.display).toMatchSnapshot();
+
+    hideRemoveElements({
+        remove: [document.querySelector('#id-2'), document.querySelector('#id-4')],
+        hide: [],
+      },
+      false,
+    );
+
+    // Check not removed
+    expect((<HTMLElement>document.querySelector('#id-2')).style.display).toMatchSnapshot();
+    expect((<HTMLElement>document.querySelector('#id-4')).style.display).toMatchSnapshot();
+  });
+});

--- a/lib/clientSideScripts/hideRemoveElements.ts
+++ b/lib/clientSideScripts/hideRemoveElements.ts
@@ -1,0 +1,7 @@
+/**
+ * Hide or remove elements on the page
+ */
+export default function hideRemoveElements(hideRemoveElements: { hide: HTMLElement[], remove: HTMLElement[] }, hideRemove: boolean): void {
+  hideRemoveElements.hide.forEach(element => element.style.visibility = hideRemove ? 'hidden' : '');
+  hideRemoveElements.remove.forEach(element => element.style.display = hideRemove ? 'none' : '');
+}

--- a/lib/commands/checkElement.ts
+++ b/lib/commands/checkElement.ts
@@ -27,6 +27,8 @@ export default async function checkElement(
       ...('disableCSSAnimation' in checkElementOptions.method ? {disableCSSAnimation: checkElementOptions.method.disableCSSAnimation} : {}),
       ...('hideScrollBars' in checkElementOptions.method ? {hideScrollBars: checkElementOptions.method.hideScrollBars} : {}),
       ...('resizeDimensions' in checkElementOptions.method ? {resizeDimensions: checkElementOptions.method.resizeDimensions} : {}),
+      ...{hideElements: checkElementOptions.method.hideElements || []},
+      ...{removeElements: checkElementOptions.method.removeElements || []},
     }
   };
   const {devicePixelRatio, fileName} = await saveElement(methods, instanceData, folders, element, tag, saveElementOptions);

--- a/lib/commands/checkFullPageScreen.ts
+++ b/lib/commands/checkFullPageScreen.ts
@@ -34,6 +34,8 @@ export default async function checkFullPageScreen(
           : {}
       ),
       ...('hideScrollBars' in checkFullPageOptions.method ? {hideScrollBars: checkFullPageOptions.method.hideScrollBars} : {}),
+      ...{hideElements: checkFullPageOptions.method.hideElements || []},
+      ...{removeElements: checkFullPageOptions.method.removeElements || []},
     }
   };
   const {devicePixelRatio, fileName} = await saveFullPageScreen(methods, instanceData, folders, tag, saveFullPageOptions);

--- a/lib/commands/checkFullPageScreen.ts
+++ b/lib/commands/checkFullPageScreen.ts
@@ -36,6 +36,7 @@ export default async function checkFullPageScreen(
       ...('hideScrollBars' in checkFullPageOptions.method ? {hideScrollBars: checkFullPageOptions.method.hideScrollBars} : {}),
       ...{hideElements: checkFullPageOptions.method.hideElements || []},
       ...{removeElements: checkFullPageOptions.method.removeElements || []},
+      ...{hideAfterFirstScroll: checkFullPageOptions.method.hideAfterFirstScroll || []},
     }
   };
   const {devicePixelRatio, fileName} = await saveFullPageScreen(methods, instanceData, folders, tag, saveFullPageOptions);

--- a/lib/commands/checkScreen.ts
+++ b/lib/commands/checkScreen.ts
@@ -25,6 +25,8 @@ export default async function checkScreen(
     method: {
       ...('disableCSSAnimation' in checkScreenOptions.method ? {disableCSSAnimation: checkScreenOptions.method.disableCSSAnimation} : {}),
       ...('hideScrollBars' in checkScreenOptions.method ? {hideScrollBars: checkScreenOptions.method.hideScrollBars} : {}),
+      ...{hideElements: checkScreenOptions.method.hideElements || []},
+      ...{removeElements: checkScreenOptions.method.removeElements || []},
     }
   };
   const {devicePixelRatio, fileName} = await saveScreen(methods, instanceData, folders, tag, saveScreenOptions);

--- a/lib/commands/element.interfaces.ts
+++ b/lib/commands/element.interfaces.ts
@@ -18,6 +18,10 @@ export interface SaveElementMethodOptions {
   resizeDimensions?: ResizeDimensions | number;
   // The padding that needs to be added to the tool bar on iOS and Android
   toolBarShadowPadding?: number;
+  // Elements that need to be hidden (visibility: hidden) before saving a screenshot
+  hideElements?: HTMLElement[];
+  // Elements that need to be removed (display: none) before saving a screenshot
+  removeElements?: HTMLElement[];
 }
 
 interface CheckOptions extends SaveElementMethodOptions, CheckMethodOptions {

--- a/lib/commands/fullPage.interfaces.ts
+++ b/lib/commands/fullPage.interfaces.ts
@@ -20,6 +20,10 @@ interface SaveFullPageMethodOptions {
   resizeDimensions?: ResizeDimensions | number;
   // The padding that needs to be added to the tool bar on iOS and Android
   toolBarShadowPadding?: number;
+  // Elements that need to be hidden (visibility: hidden) before saving a screenshot
+  hideElements?: HTMLElement[];
+  // Elements that need to be removed (display: none) before saving a screenshot
+  removeElements?: HTMLElement[];
 }
 
 interface CheckOptions extends SaveFullPageMethodOptions, CheckMethodOptions {

--- a/lib/commands/fullPage.interfaces.ts
+++ b/lib/commands/fullPage.interfaces.ts
@@ -24,6 +24,8 @@ interface SaveFullPageMethodOptions {
   hideElements?: HTMLElement[];
   // Elements that need to be removed (display: none) before saving a screenshot
   removeElements?: HTMLElement[];
+  // Elements that need to be hidden after the first scroll for a fullpage scroll
+  hideAfterFirstScroll: HTMLElement[];
 }
 
 interface CheckOptions extends SaveFullPageMethodOptions, CheckMethodOptions {

--- a/lib/commands/saveElement.ts
+++ b/lib/commands/saveElement.ts
@@ -71,6 +71,7 @@ export default async function saveElement(
   const afterOptions: AfterScreenshotOptions = {
     actualFolder: folders.actualFolder,
     base64Image: croppedBase64Image,
+    hideElements,
     hideScrollBars,
     filePath: {
       browserName: enrichedInstanceData.browserName,
@@ -93,6 +94,7 @@ export default async function saveElement(
       screenWidth: enrichedInstanceData.dimensions.window.screenWidth,
       tag,
     },
+    removeElements,
   };
 
   // 7.  Return the data

--- a/lib/commands/saveElement.ts
+++ b/lib/commands/saveElement.ts
@@ -11,6 +11,7 @@ import {SaveElementOptions} from './element.interfaces';
 import {ElementRectanglesOptions, RectanglesOutput} from '../methods/rectangles.interfaces';
 import {BeforeScreenshotOptions, BeforeScreenshotResult} from '../helpers/beforeScreenshot.interface';
 import {DEFAULT_RESIZE_DIMENSIONS} from '../helpers/constants';
+import {ResizeDimensions} from '../methods/images.interfaces';
 
 /**
  * Saves an image of an element
@@ -34,14 +35,18 @@ export default async function saveElement(
   const hideScrollBars: boolean = 'hideScrollBars' in saveElementOptions.method
     ? saveElementOptions.method.hideScrollBars
     : saveElementOptions.wic.hideScrollBars;
-  const resizeDimensions = saveElementOptions.method.resizeDimensions || DEFAULT_RESIZE_DIMENSIONS;
+  const resizeDimensions: ResizeDimensions | number = saveElementOptions.method.resizeDimensions || DEFAULT_RESIZE_DIMENSIONS;
+  const hideElements: HTMLElement[] = saveElementOptions.method.hideElements || [];
+  const removeElements: HTMLElement[] = saveElementOptions.method.removeElements || [];
 
   // 2.  Prepare the beforeScreenshot
   const beforeOptions: BeforeScreenshotOptions = {
     instanceData,
     addressBarShadowPadding,
     disableCSSAnimation,
+    hideElements,
     noScrollBars: hideScrollBars,
+    removeElements,
     toolBarShadowPadding,
   };
   const enrichedInstanceData: BeforeScreenshotResult = await beforeScreenshot(methods.executor, beforeOptions, true);

--- a/lib/commands/saveFullPageScreen.ts
+++ b/lib/commands/saveFullPageScreen.ts
@@ -70,6 +70,7 @@ export default async function saveFullPageScreen(
   const afterOptions = {
     actualFolder: folders.actualFolder,
     base64Image: fullPageBase64Image,
+    hideElements,
     hideScrollBars,
     filePath: {
       autoSaveBaseline,
@@ -93,6 +94,7 @@ export default async function saveFullPageScreen(
       screenWidth: enrichedInstanceData.dimensions.window.screenWidth,
       tag,
     },
+    removeElements,
   };
 
   // 6.  Return the data

--- a/lib/commands/saveFullPageScreen.ts
+++ b/lib/commands/saveFullPageScreen.ts
@@ -8,7 +8,7 @@ import {InstanceData} from '../methods/instanceData.interfaces';
 import {Folders} from '../base.interface';
 import {SaveFullPageOptions} from './fullPage.interfaces';
 import {BeforeScreenshotOptions, BeforeScreenshotResult} from '../helpers/beforeScreenshot.interface';
-import {FullPageScreenshotsData} from '../methods/screenshots.interfaces';
+import {FullPageScreenshotDataOptions, FullPageScreenshotsData} from '../methods/screenshots.interfaces';
 
 /**
  * Saves an image of the full page
@@ -36,6 +36,7 @@ export default async function saveFullPageScreen(
     : saveFullPageOptions.wic.fullPageScrollTimeout;
   const hideElements: HTMLElement[] = saveFullPageOptions.method.hideElements || [];
   const removeElements: HTMLElement[] = saveFullPageOptions.method.removeElements || [];
+  const hideAfterFirstScroll: HTMLElement[] = saveFullPageOptions.method.hideAfterFirstScroll || [];
 
   // 2.  Prepare the beforeScreenshot
   const beforeOptions: BeforeScreenshotOptions = {
@@ -50,10 +51,11 @@ export default async function saveFullPageScreen(
   const enrichedInstanceData: BeforeScreenshotResult = await beforeScreenshot(methods.executor, beforeOptions, true);
 
   // 3.  Fullpage screenshots are taken per scrolled viewport
-  const fullPageScreenshotOptions = {
+  const fullPageScreenshotOptions: FullPageScreenshotDataOptions = {
     addressBarShadowPadding: enrichedInstanceData.addressBarShadowPadding,
     devicePixelRatio: enrichedInstanceData.dimensions.window.devicePixelRatio,
     fullPageScrollTimeout,
+    hideAfterFirstScroll,
     innerHeight: enrichedInstanceData.dimensions.window.innerHeight,
     isAndroid: enrichedInstanceData.isAndroid,
     isAndroidChromeDriverScreenshot: enrichedInstanceData.isAndroidChromeDriverScreenshot,
@@ -61,7 +63,11 @@ export default async function saveFullPageScreen(
     isIos: enrichedInstanceData.isIos,
     toolBarShadowPadding: enrichedInstanceData.toolBarShadowPadding,
   };
-  const screenshotsData: FullPageScreenshotsData = await getBase64FullPageScreenshotsData(methods.screenShot, methods.executor, fullPageScreenshotOptions);
+  const screenshotsData: FullPageScreenshotsData = await getBase64FullPageScreenshotsData(
+    methods.screenShot,
+    methods.executor,
+    fullPageScreenshotOptions,
+  );
 
   // 4.  Make a fullpage base64 image
   const fullPageBase64Image: string = await makeFullPageBase64Image(screenshotsData);

--- a/lib/commands/saveFullPageScreen.ts
+++ b/lib/commands/saveFullPageScreen.ts
@@ -34,13 +34,17 @@ export default async function saveFullPageScreen(
   const fullPageScrollTimeout: number = 'fullPageScrollTimeout' in saveFullPageOptions.method
     ? saveFullPageOptions.method.fullPageScrollTimeout
     : saveFullPageOptions.wic.fullPageScrollTimeout;
+  const hideElements: HTMLElement[] = saveFullPageOptions.method.hideElements || [];
+  const removeElements: HTMLElement[] = saveFullPageOptions.method.removeElements || [];
 
   // 2.  Prepare the beforeScreenshot
   const beforeOptions: BeforeScreenshotOptions = {
     instanceData,
     addressBarShadowPadding,
     disableCSSAnimation,
+    hideElements,
     noScrollBars: hideScrollBars,
+    removeElements,
     toolBarShadowPadding,
   };
   const enrichedInstanceData: BeforeScreenshotResult = await beforeScreenshot(methods.executor, beforeOptions, true);

--- a/lib/commands/saveScreen.ts
+++ b/lib/commands/saveScreen.ts
@@ -32,13 +32,17 @@ export default async function saveScreen(
   const hideScrollBars: boolean = 'hideScrollBars' in saveScreenOptions.method
     ? saveScreenOptions.method.hideScrollBars
     : saveScreenOptions.wic.hideScrollBars;
+  const hideElements: HTMLElement[] = saveScreenOptions.method.hideElements || [];
+  const removeElements: HTMLElement[] = saveScreenOptions.method.removeElements || [];
 
   // 2.  Prepare the beforeScreenshot
   const beforeOptions: BeforeScreenshotOptions = {
     instanceData,
     addressBarShadowPadding,
     disableCSSAnimation,
+    hideElements,
     noScrollBars: hideScrollBars,
+    removeElements,
     toolBarShadowPadding,
   };
   const enrichedInstanceData: BeforeScreenshotResult = await beforeScreenshot(methods.executor, beforeOptions);

--- a/lib/commands/saveScreen.ts
+++ b/lib/commands/saveScreen.ts
@@ -68,6 +68,7 @@ export default async function saveScreen(
   const afterOptions: AfterScreenshotOptions = {
     actualFolder: folders.actualFolder,
     base64Image: croppedBase64Image,
+    hideElements,
     hideScrollBars,
     filePath: {
       browserName: enrichedInstanceData.browserName,
@@ -90,6 +91,7 @@ export default async function saveScreen(
       screenWidth: enrichedInstanceData.dimensions.window.screenWidth,
       tag,
     },
+    removeElements,
   };
 
   // 6.  Return the data

--- a/lib/commands/screen.interfaces.ts
+++ b/lib/commands/screen.interfaces.ts
@@ -11,6 +11,10 @@ interface SaveScreenMethodOptions {
   disableCSSAnimation?: boolean;
   // Hide scrollbars, this is optional
   hideScrollBars?: boolean;
+  // Elements that need to be hidden (visibility: hidden) before saving a screenshot
+  hideElements?: HTMLElement[];
+  // Elements that need to be removed (display: none) before saving a screenshot
+  removeElements?: HTMLElement[];
 }
 
 interface CheckOptions extends SaveScreenMethodOptions, CheckMethodOptions {

--- a/lib/helpers/afterScreenshot.interfaces.ts
+++ b/lib/helpers/afterScreenshot.interfaces.ts
@@ -18,6 +18,10 @@ export interface AfterScreenshotOptions {
   filePath: ScreenshotFilePathOptions;
   // The file name options object
   fileName: ScreenshotFileNameOptions;
+  // Elements that need to be hidden (visibility: hidden) before saving a screenshot
+  hideElements?: HTMLElement[];
+  // Elements that need to be removed (display: none) before saving a screenshot
+  removeElements?: HTMLElement[];
 }
 
 export interface ScreenshotFilePathOptions {

--- a/lib/helpers/afterScreenshot.interfaces.ts
+++ b/lib/helpers/afterScreenshot.interfaces.ts
@@ -19,9 +19,9 @@ export interface AfterScreenshotOptions {
   // The file name options object
   fileName: ScreenshotFileNameOptions;
   // Elements that need to be hidden (visibility: hidden) before saving a screenshot
-  hideElements?: HTMLElement[];
+  hideElements: HTMLElement[];
   // Elements that need to be removed (display: none) before saving a screenshot
-  removeElements?: HTMLElement[];
+  removeElements: HTMLElement[];
 }
 
 export interface ScreenshotFilePathOptions {

--- a/lib/helpers/afterScreenshot.spec.ts
+++ b/lib/helpers/afterScreenshot.spec.ts
@@ -33,7 +33,9 @@ describe('afterScreenshot', () => {
         screenHeight: 900,
         screenWidth: 1440,
         tag: 'tag',
-      }
+      },
+      hideElements: [<HTMLElement><any>'<div></div>'],
+      removeElements: [<HTMLElement><any>'<div></div>'],
     };
 
     expect(await afterScreenshot(MOCKED_EXECUTOR, options)).toEqual({

--- a/lib/helpers/afterScreenshot.ts
+++ b/lib/helpers/afterScreenshot.ts
@@ -6,13 +6,22 @@ import {saveBase64Image} from '../methods/images';
 import {join} from 'path';
 import {Executor} from '../methods/methods.interface';
 import {AfterScreenshotOptions, ScreenshotOutput} from './afterScreenshot.interfaces';
+import hideRemoveElements from '../clientSideScripts/hideRemoveElements';
 
 /**
  * Methods that need to be executed after a screenshot has been taken
  * to set all back to the original state
  */
-export default async function afterScreenshot(executor: Executor, options:AfterScreenshotOptions):Promise<ScreenshotOutput> {
-  const {actualFolder, base64Image, fileName: fileNameOptions, filePath, hideScrollBars: noScrollBars} = options;
+export default async function afterScreenshot(executor: Executor, options: AfterScreenshotOptions): Promise<ScreenshotOutput> {
+  const {
+    actualFolder,
+    base64Image,
+    fileName: fileNameOptions,
+    filePath,
+    hideElements,
+    hideScrollBars: noScrollBars,
+    removeElements,
+  } = options;
 
   // Get the path
   const path = getAndCreatePath(actualFolder, filePath);
@@ -25,6 +34,11 @@ export default async function afterScreenshot(executor: Executor, options:AfterS
 
   // Show the scrollbars again
   await executor(hideScrollBars, !noScrollBars);
+
+  // Show elements again
+  if (hideElements.length > 0 || removeElements.length > 0) {
+    await executor(hideRemoveElements, {hide: hideElements, remove: removeElements}, false);
+  }
 
   // Remove the custom set css
   await executor(removeCustomCss, CUSTOM_CSS_ID);

--- a/lib/helpers/beforeScreenshot.interface.ts
+++ b/lib/helpers/beforeScreenshot.interface.ts
@@ -11,6 +11,10 @@ export interface BeforeScreenshotOptions {
   noScrollBars: boolean;
   // The padding that needs to be added to the tool bar on iOS and Android
   toolBarShadowPadding: number;
+  // Elements that need to be hidden (visibility: hidden) before saving a screenshot
+  hideElements: HTMLElement[];
+  // Elements that need to be removed (display: none) before saving a screenshot
+  removeElements: HTMLElement[];
 }
 
 export interface BeforeScreenshotResult extends EnrichedInstanceData {}

--- a/lib/helpers/beforeScreenshot.spec.ts
+++ b/lib/helpers/beforeScreenshot.spec.ts
@@ -17,6 +17,8 @@ describe('beforeScreenshot', () => {
       disableCSSAnimation: true,
       noScrollBars: true,
       toolBarShadowPadding: 6,
+      hideElements: [<HTMLElement><any>'<div></div>'],
+      removeElements: [<HTMLElement><any>'<div></div>'],
     };
 
     expect(await beforeScreenshot(MOCKED_EXECUTOR, options)).toMatchSnapshot();
@@ -38,6 +40,8 @@ describe('beforeScreenshot', () => {
       disableCSSAnimation: true,
       noScrollBars: true,
       toolBarShadowPadding: 6,
+      hideElements: [<HTMLElement><any>'<div></div>'],
+      removeElements: [<HTMLElement><any>'<div></div>'],
     };
 
     expect(await beforeScreenshot(MOCKED_EXECUTOR, options, true)).toMatchSnapshot();

--- a/lib/helpers/beforeScreenshot.ts
+++ b/lib/helpers/beforeScreenshot.ts
@@ -5,6 +5,7 @@ import {getAddressBarShadowPadding, getToolBarShadowPadding} from './utils';
 import getEnrichedInstanceData from '../methods/instanceData';
 import {BeforeScreenshotOptions, BeforeScreenshotResult} from './beforeScreenshot.interface';
 import {Executor} from '../methods/methods.interface';
+import hideRemoveElements from '../clientSideScripts/hideRemoveElements';
 
 /**
  * Methods that need to be executed before a screenshot will be taken
@@ -16,7 +17,14 @@ export default async function beforeScreenshot(
 ): Promise<BeforeScreenshotResult> {
 
   const {browserName, nativeWebScreenshot, platformName} = options.instanceData;
-  const {addressBarShadowPadding, disableCSSAnimation, noScrollBars, toolBarShadowPadding} = options;
+  const {
+    addressBarShadowPadding,
+    disableCSSAnimation,
+    hideElements,
+    noScrollBars,
+    removeElements,
+    toolBarShadowPadding,
+  } = options;
   const addressBarPadding = getAddressBarShadowPadding({
     platformName,
     browserName,
@@ -28,6 +36,11 @@ export default async function beforeScreenshot(
 
   // Hide the scrollbars
   await executor(hideScrollBars, noScrollBars);
+
+  // Hide and or Remove elements
+  if (hideElements.length > 0 || removeElements.length > 0) {
+    await executor(hideRemoveElements, {hide: hideElements, remove: removeElements}, true);
+  }
 
   // Set some custom css
   await executor(setCustomCss, {addressBarPadding, disableCSSAnimation, id: CUSTOM_CSS_ID, toolBarPadding});

--- a/lib/methods/screenshots.interfaces.ts
+++ b/lib/methods/screenshots.interfaces.ts
@@ -28,6 +28,8 @@ export interface FullPageScreenshotDataOptions {
   devicePixelRatio: number;
   // The amount of milliseconds to wait for a new scroll
   fullPageScrollTimeout: number;
+  // Elements that need to be hidden after the first scroll for a fullpage scroll
+  hideAfterFirstScroll: HTMLElement[];
   // The innerheight
   innerHeight: number;
   // If the instance is an Android device
@@ -55,6 +57,8 @@ export interface FullPageScreenshotNativeMobileOptions {
   statusAddressBarHeight: number;
   // The address bar padding for iOS or Android
   toolBarShadowPadding: number;
+  // Elements that need to be hidden after the first scroll for a fullpage scroll
+  hideAfterFirstScroll: HTMLElement[];
 }
 
 export interface FullPageScreenshotOptions {
@@ -64,4 +68,6 @@ export interface FullPageScreenshotOptions {
   fullPageScrollTimeout: number;
   // The innerheight
   innerHeight: number;
+  // Elements that need to be hidden after the first scroll for a fullpage scroll
+  hideAfterFirstScroll: HTMLElement[];
 }

--- a/lib/methods/screenshots.spec.ts
+++ b/lib/methods/screenshots.spec.ts
@@ -18,6 +18,7 @@ describe('screenshots', () => {
         isAndroidChromeDriverScreenshot: false,
         isIos: false,
         toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [],
       };
       const MOCKED_EXECUTOR = jest.fn()
         .mockResolvedValueOnce({statusAddressBar: {height: 56}})
@@ -41,10 +42,11 @@ describe('screenshots', () => {
         isAndroidChromeDriverScreenshot: true,
         isIos: false,
         toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [],
       };
       const MOCKED_EXECUTOR = jest.fn()
-        // THIS NEEDS TO BE FIXED IN THE FUTURE
-        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+      // THIS NEEDS TO BE FIXED IN THE FUTURE
+      // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(1200)
@@ -58,7 +60,7 @@ describe('screenshots', () => {
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });
 
-    it('should get the iOS fullpage screenshot data', async() => {
+    it('should get the iOS fullpage screenshot data', async () => {
       const options: FullPageScreenshotDataOptions = {
         addressBarShadowPadding: 6,
         devicePixelRatio: 2,
@@ -69,6 +71,7 @@ describe('screenshots', () => {
         isAndroidChromeDriverScreenshot: false,
         isIos: true,
         toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [],
       };
       const MOCKED_EXECUTOR = jest.fn()
         .mockResolvedValueOnce({statusAddressBar: {height: 94}})
@@ -97,10 +100,11 @@ describe('screenshots', () => {
         isAndroidChromeDriverScreenshot: false,
         isIos: false,
         toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [],
       };
       const MOCKED_EXECUTOR = jest.fn()
-        // THIS NEEDS TO BE FIXED IN THE FUTURE
-        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+      // THIS NEEDS TO BE FIXED IN THE FUTURE
+      // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(3200)

--- a/lib/methods/screenshots.ts
+++ b/lib/methods/screenshots.ts
@@ -12,6 +12,7 @@ import {
   FullPageScreenshotsData,
 } from './screenshots.interfaces';
 import {StatusAddressToolBarHeight} from '../clientSideScripts/statusAddressToolBarHeight.interfaces';
+import hideRemoveElements from '../clientSideScripts/hideRemoveElements';
 
 /**
  * Take a full page screenshots for desktop / iOS / Android
@@ -25,6 +26,7 @@ export async function getBase64FullPageScreenshotsData(
     addressBarShadowPadding,
     devicePixelRatio,
     fullPageScrollTimeout,
+    hideAfterFirstScroll,
     innerHeight,
     isAndroid,
     isAndroidNativeWebScreenshot,
@@ -35,6 +37,7 @@ export async function getBase64FullPageScreenshotsData(
   const desktopOptions = {
     devicePixelRatio,
     fullPageScrollTimeout,
+    hideAfterFirstScroll,
     innerHeight,
   };
   const nativeMobileOptions = {
@@ -52,7 +55,7 @@ export async function getBase64FullPageScreenshotsData(
 
     return getFullPageScreenshotsDataNativeMobile(takeScreenshot, executor, androidNativeMobileOptions);
   } else if (isAndroid && isAndroidChromeDriverScreenshot) {
-    const chromeDriverOptions = {devicePixelRatio, fullPageScrollTimeout, innerHeight};
+    const chromeDriverOptions = {devicePixelRatio, fullPageScrollTimeout, hideAfterFirstScroll, innerHeight};
 
     // Create a fullpage screenshot for Android when the ChromeDriver provides the screenshots
     return getFullPageScreenshotsDataAndroidChromeDriver(takeScreenshot, executor, chromeDriverOptions);
@@ -86,6 +89,7 @@ export async function getFullPageScreenshotsDataNativeMobile(
     addressBarShadowPadding,
     devicePixelRatio,
     fullPageScrollTimeout,
+    hideAfterFirstScroll,
     innerHeight,
     statusAddressBarHeight,
     toolBarShadowPadding,
@@ -104,6 +108,11 @@ export async function getFullPageScreenshotsDataNativeMobile(
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
+
+    // Elements that need to be hidden after the first scroll for a fullpage scroll
+    if (i === 1 && hideAfterFirstScroll.length > 0) {
+      await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+    }
 
     // Take the screenshot and get the width
     const screenshot = await takeBase64Screenshot(takeScreenshot);
@@ -136,6 +145,11 @@ export async function getFullPageScreenshotsDataNativeMobile(
     });
   }
 
+  // Put back the hidden elements to visible
+  if (hideAfterFirstScroll.length > 0) {
+    await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
+  }
+
   return {
     ...calculateDprData({
       fullPageHeight: scrollHeight - addressBarShadowPadding - toolBarShadowPadding,
@@ -154,7 +168,7 @@ export async function getFullPageScreenshotsDataAndroidChromeDriver(
   options: FullPageScreenshotOptions,
 ): Promise<FullPageScreenshotsData> {
   const viewportScreenshots = [];
-  const {devicePixelRatio, fullPageScrollTimeout, innerHeight} = options;
+  const {devicePixelRatio, fullPageScrollTimeout, hideAfterFirstScroll, innerHeight} = options;
 
   // Start with an empty array, during the scroll it will be filled because a page could also have a lazy loading
   const amountOfScrollsArray = [];
@@ -168,6 +182,11 @@ export async function getFullPageScreenshotsDataAndroidChromeDriver(
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
+
+    // Elements that need to be hidden after the first scroll for a fullpage scroll
+    if (i === 1 && hideAfterFirstScroll.length > 0) {
+      await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+    }
 
     // Take the screenshot
     const screenshot = await takeBase64Screenshot(takeScreenshot);
@@ -198,6 +217,11 @@ export async function getFullPageScreenshotsDataAndroidChromeDriver(
     });
   }
 
+  // Put back the hidden elements to visible
+  if (hideAfterFirstScroll.length > 0) {
+    await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
+  }
+
   return {
     ...calculateDprData({
       fullPageHeight: scrollHeight,
@@ -216,7 +240,7 @@ export async function getFullPageScreenshotsDataDesktop(
   options: FullPageScreenshotOptions,
 ): Promise<FullPageScreenshotsData> {
   const viewportScreenshots = [];
-  const {devicePixelRatio, fullPageScrollTimeout, innerHeight} = options;
+  const {devicePixelRatio, fullPageScrollTimeout, hideAfterFirstScroll, innerHeight} = options;
 
   // Start with an empty array, during the scroll it will be filled because a page could also have a lazy loading
   const amountOfScrollsArray = [];
@@ -230,6 +254,11 @@ export async function getFullPageScreenshotsDataDesktop(
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
+
+    // Elements that need to be hidden after the first scroll for a fullpage scroll
+    if (i === 1 && hideAfterFirstScroll.length > 0) {
+      await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+    }
 
     // Take the screenshot
     const screenshot = await takeBase64Screenshot(takeScreenshot);
@@ -262,6 +291,11 @@ export async function getFullPageScreenshotsDataDesktop(
       }, devicePixelRatio),
       screenshot,
     });
+  }
+
+  // Put back the hidden elements to visible
+  if (hideAfterFirstScroll.length > 0) {
+    await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
   }
 
   return {

--- a/lib/mocks/mocks.ts
+++ b/lib/mocks/mocks.ts
@@ -13,6 +13,8 @@ export const BEFORE_SCREENSHOT_OPTIONS: BeforeScreenshotOptions = {
   disableCSSAnimation: true,
   noScrollBars: true,
   toolBarShadowPadding: 6,
+  hideElements: [<HTMLElement><any>'<div></div>'],
+  removeElements: [<HTMLElement><any>'<div></div>'],
 };
 export const NAVIGATOR_APP_VERSIONS = {
   ANDROID: {


### PR DESCRIPTION
This PR will add 2 new methods for the users that can be added to the methods :

- `hideElements`: this can be an array of elements that will add the property `visibility:hidden` to the elements so they will be _hidden_ in the UI
- `removeElements`: this can be an array of elements that will add the property `display:none` to the elements so they will be _removed_ from the UI

Both methods are based on https://github.com/wswebcreation/webdriver-image-comparison/issues/4

Secondly this will add the method `hideAfterFirstScroll` for `saveFullPageScreen` and `checkFullPageScreen` and will basically hide 1 or multiple elements from the UI after the first scroll. This will hide for example sticky headers  from a large screenshot. See for example this, the left side was the old way, the right side it the new way

![new-feature](https://user-images.githubusercontent.com/11979740/56843837-120b5500-686c-11e9-9990-4cb3bea8a333.jpg)
