### PR TITLE
Optimize get page scrollheight

### DIFF
--- a/lib/clientSideScripts/getDocumentScrollHeight.spec.ts
+++ b/lib/clientSideScripts/getDocumentScrollHeight.spec.ts
@@ -1,9 +1,50 @@
 import getDocumentScrollHeight from './getDocumentScrollHeight';
 
+const CONFIGURABLE = {
+  writable: true,
+  configurable: true,
+};
+
 describe('getDocumentScrollHeight', () => {
-  it('should check if the document.documentElement.scrollHeight function has been called', () => {
+  it('should return the bodyScrollHeight', () => {
+    // For viewPortHeight
+    Object.defineProperty(document.documentElement, 'clientHeight', {value: 500, ...CONFIGURABLE});
+    Object.defineProperty(window, 'innerHeight', {value: 500, ...CONFIGURABLE});
+    // For scrollHeight
+    Object.defineProperty(document.documentElement, 'scrollHeight', {value: 500, ...CONFIGURABLE});
+    // For bodyScrollHeight
+    Object.defineProperty(document.body, 'scrollHeight', {value: 1500, ...CONFIGURABLE});
+
+    expect(getDocumentScrollHeight()).toEqual(1500);
+  });
+
+  it('should return the scrollHeight', () => {
+    // For viewPortHeight
+    Object.defineProperty(document.documentElement, 'clientHeight', {value: 500, ...CONFIGURABLE});
+    Object.defineProperty(window, 'innerHeight', {value: 500, ...CONFIGURABLE});
+    // For scrollHeight
+    Object.defineProperty(document.documentElement, 'scrollHeight', {value: 2250, ...CONFIGURABLE});
+    // For bodyScrollHeight
+    Object.defineProperty(document.body, 'scrollHeight', {value: 1500, ...CONFIGURABLE});
+
+    expect(getDocumentScrollHeight()).toEqual(2250);
+  });
+
+  it('should return the height of the largest node', () => {
+    // For viewPortHeight
+    Object.defineProperty(document.documentElement, 'clientHeight', {value: 1500, ...CONFIGURABLE});
+    Object.defineProperty(window, 'innerHeight', {value: 1500, ...CONFIGURABLE});
+    // For scrollHeight
+    Object.defineProperty(document.documentElement, 'scrollHeight', {value: 1500, ...CONFIGURABLE});
+    // For bodyScrollHeight
+    Object.defineProperty(document.body, 'scrollHeight', {value: 1500, ...CONFIGURABLE});
+    document.body.innerHTML =
+      '<div>' +
+      '  <span style="height: 200px;width: 50px"/>' +
+      '  <div style="height: 500px;width: 50px" />' +
+      '</div>';
+
+    // Some lines and the outcome can't be tested because we can't mock `scrollHeight` and `clientHeight`
     getDocumentScrollHeight();
-    // I can't verify the call of the document.documentElement.scrollHeight with Jest, so there is no verification here, sorry :(
-    // If you know a way, please add it here ;-)
   });
 });

--- a/lib/clientSideScripts/getDocumentScrollHeight.ts
+++ b/lib/clientSideScripts/getDocumentScrollHeight.ts
@@ -2,5 +2,41 @@
  * Get the document scroll height, this means the actual height of the page from the top to the bottom of the DOM
  */
 export default function getDocumentScrollHeight(): number {
-  return document.documentElement.scrollHeight;
+  const viewPortHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+  const scrollHeight = document.documentElement.scrollHeight;
+  const bodyScrollHeight = document.body.scrollHeight;
+
+  // In some situations the default scrollheight can be equal to the viewport height
+  // but the body scroll height can be different, then return that one
+  if ((viewPortHeight === scrollHeight) && (bodyScrollHeight > scrollHeight)) {
+    return bodyScrollHeight;
+  }
+
+  // In some cases we can have a challenge determining the height of the page
+  // due to for example a `vh` property on the body element.
+  // If that is the case we need to walk over all the elements and determine the highest element
+  // this is a very time consuming thing, so our last hope :(
+  if (bodyScrollHeight === scrollHeight && bodyScrollHeight === viewPortHeight){
+    let pageHeight = 0;
+
+    // @ts-ignore
+    function findHighestNode(nodesList: any) {
+      for (var i = nodesList.length - 1; i >= 0; i--) {
+        if (nodesList[i].scrollHeight && nodesList[i].clientHeight) {
+          var elHeight = Math.max(nodesList[i].scrollHeight, nodesList[i].clientHeight);
+          pageHeight = Math.max(elHeight, pageHeight);
+        }
+        if (nodesList[i].childNodes.length) {
+          findHighestNode(nodesList[i].childNodes);
+        }
+      }
+    }
+
+    findHighestNode(document.documentElement.childNodes);
+
+    return pageHeight;
+  }
+
+  // The scrollHeight is good enough
+  return scrollHeight;
 }

--- a/lib/clientSideScripts/getDocumentScrollHeight.ts
+++ b/lib/clientSideScripts/getDocumentScrollHeight.ts
@@ -17,13 +17,14 @@ export default function getDocumentScrollHeight(): number {
   // If that is the case we need to walk over all the elements and determine the highest element
   // this is a very time consuming thing, so our last hope :(
   let pageHeight = 0;
-  let largestNodeElement: HTMLElement;
+  let largestNodeElement = document.querySelector('body');
 
-  if (bodyScrollHeight === scrollHeight && bodyScrollHeight === viewPortHeight){
+  if (bodyScrollHeight === scrollHeight && bodyScrollHeight === viewPortHeight) {
     findHighestNode(document.documentElement.childNodes);
 
     // There could be some elements above this largest element,
     // add that on top
+    /* istanbul ignore next */
     return pageHeight + largestNodeElement.getBoundingClientRect().top;
   }
 
@@ -38,10 +39,11 @@ export default function getDocumentScrollHeight(): number {
     for (let i = nodesList.length - 1; i >= 0; i--) {
       const currentNode = nodesList[i];
 
+      /* istanbul ignore next */
       if (currentNode.scrollHeight && currentNode.clientHeight) {
         const elHeight = Math.max(currentNode.scrollHeight, currentNode.clientHeight);
         pageHeight = Math.max(elHeight, pageHeight);
-        if(elHeight === pageHeight){
+        if (elHeight === pageHeight) {
           largestNodeElement = currentNode;
         }
       }

--- a/lib/clientSideScripts/getDocumentScrollHeight.ts
+++ b/lib/clientSideScripts/getDocumentScrollHeight.ts
@@ -16,27 +16,39 @@ export default function getDocumentScrollHeight(): number {
   // due to for example a `vh` property on the body element.
   // If that is the case we need to walk over all the elements and determine the highest element
   // this is a very time consuming thing, so our last hope :(
+  let pageHeight = 0;
+  let largestNodeElement: HTMLElement;
+
   if (bodyScrollHeight === scrollHeight && bodyScrollHeight === viewPortHeight){
-    let pageHeight = 0;
-
-    // @ts-ignore
-    function findHighestNode(nodesList: any) {
-      for (var i = nodesList.length - 1; i >= 0; i--) {
-        if (nodesList[i].scrollHeight && nodesList[i].clientHeight) {
-          var elHeight = Math.max(nodesList[i].scrollHeight, nodesList[i].clientHeight);
-          pageHeight = Math.max(elHeight, pageHeight);
-        }
-        if (nodesList[i].childNodes.length) {
-          findHighestNode(nodesList[i].childNodes);
-        }
-      }
-    }
-
     findHighestNode(document.documentElement.childNodes);
 
-    return pageHeight;
+    // There could be some elements above this largest element,
+    // add that on top
+    return pageHeight + largestNodeElement.getBoundingClientRect().top;
   }
 
   // The scrollHeight is good enough
   return scrollHeight;
+
+  /**
+   * Find the largest html element on the page
+   * @param nodesList
+   */
+  function findHighestNode(nodesList: any) {
+    for (let i = nodesList.length - 1; i >= 0; i--) {
+      const currentNode = nodesList[i];
+
+      if (currentNode.scrollHeight && currentNode.clientHeight) {
+        const elHeight = Math.max(currentNode.scrollHeight, currentNode.clientHeight);
+        pageHeight = Math.max(elHeight, pageHeight);
+        if(elHeight === pageHeight){
+          largestNodeElement = currentNode;
+        }
+      }
+
+      if (currentNode.childNodes.length) {
+        findHighestNode(currentNode.childNodes);
+      }
+    }
+  }
 }

--- a/lib/clientSideScripts/hideScrollbars.spec.ts
+++ b/lib/clientSideScripts/hideScrollbars.spec.ts
@@ -2,14 +2,14 @@ import hideScrollBars from './hideScrollbars';
 
 describe('hideScrollBars', ()=>{
   it('should be able to hide and show the scrollbars', ()=>{
-    expect(document.documentElement.style.overflow).toMatchSnapshot();
+    expect(document.body.style.overflow).toMatchSnapshot();
 
     hideScrollBars(true);
 
-    expect(document.documentElement.style.overflow).toMatchSnapshot();
+    expect(document.body.style.overflow).toMatchSnapshot();
 
     hideScrollBars(false);
 
-    expect(document.documentElement.style.overflow).toMatchSnapshot();
+    expect(document.body.style.overflow).toMatchSnapshot();
   });
 });

--- a/lib/clientSideScripts/hideScrollbars.ts
+++ b/lib/clientSideScripts/hideScrollbars.ts
@@ -3,8 +3,8 @@
  */
 export default function hideScrollBars(hide: boolean): void {
   if (hide) {
-    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
   } else {
-    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
   }
 }

--- a/lib/clientSideScripts/scrollToPosition.spec.ts
+++ b/lib/clientSideScripts/scrollToPosition.spec.ts
@@ -1,9 +1,27 @@
 import scrollToPosition from './scrollToPosition';
 
+const CONFIGURABLE = {
+  writable: true,
+  configurable: true,
+};
+
 describe('scrollToPosition', () => {
   it('should check if the scrollTo function has been called', () => {
     window.scrollTo = jest.fn();
     scrollToPosition(150);
     expect(window.scrollTo).toBeCalledWith(0, 150);
+  });
+
+  it('should find the largest node if scrollTo does not work on the window', () => {
+    window.scrollTo = jest.fn();
+    Object.defineProperty(document.documentElement, 'scrollTop', {value: 150, ...CONFIGURABLE});
+    document.body.innerHTML =
+      '<div>' +
+      '  <span style="height: 200px;width: 50px"/>' +
+      '  <div style="height: 500px;width: 50px" />' +
+      '</div>';
+
+    scrollToPosition(150);
+    // Some lines and the outcome can't be tested because we can't mock `scrollHeight` and `clientHeight`
   });
 });

--- a/lib/clientSideScripts/scrollToPosition.ts
+++ b/lib/clientSideScripts/scrollToPosition.ts
@@ -12,6 +12,7 @@ export default function scrollToPosition(yPosition: number): void {
   // Scroll with the default way of scrolling
   window.scrollTo(0, yPosition);
 
+  /* istanbul ignore else */
   if (initialScroll === document.documentElement.scrollTop && yPosition > 0) {
     largestFirstNode(document.documentElement.childNodes).scrollTo(0, yPosition);
   }
@@ -27,11 +28,13 @@ export default function scrollToPosition(yPosition: number): void {
       node = nodesList[i];
 
       // Stop if the largest node has been found
+      /* istanbul ignore next */
       if (largestNode) {
         break;
       }
 
       // Check if the element has a scroll / client height
+      /* istanbul ignore next */
       if (node.scrollHeight && node.clientHeight) {
         const viewPortHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
         const elHeight = Math.max(node.scrollHeight, node.clientHeight);

--- a/lib/clientSideScripts/scrollToPosition.ts
+++ b/lib/clientSideScripts/scrollToPosition.ts
@@ -1,6 +1,54 @@
 /**
  * Scroll to a x = 0 and y = variable position in the screen
+ * Sometimes a scroll can't be done on the window, so the scroll needs to be done on the largest
+ * element on the screen
  */
-export default function scrollToPosition(yPosition:number):void {
-	window.scrollTo(0, yPosition);
+export default function scrollToPosition(yPosition: number): void {
+  const initialScroll = document.documentElement.scrollTop;
+
+  // If for some reason the scroll didn't work, find the first largest element and use that to scroll on
+  let largestNode: HTMLElement;
+
+  // Scroll with the default way of scrolling
+  window.scrollTo(0, yPosition);
+
+  if (initialScroll === document.documentElement.scrollTop && yPosition > 0) {
+    largestFirstNode(document.documentElement.childNodes).scrollTo(0, yPosition);
+  }
+
+  /**
+   * Find the first largest node in the page so it  can be used for scrolling
+   */
+  function largestFirstNode(nodesList: any) {
+    let node: HTMLElement;
+
+    // Loop over the nodes
+    for (let i = nodesList.length - 1; i >= 0; i--) {
+      node = nodesList[i];
+
+      // Stop if the largest node has been found
+      if (largestNode) {
+        break;
+      }
+
+      // Check if the element has a scroll / client height
+      if (node.scrollHeight && node.clientHeight) {
+        const viewPortHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+        const elHeight = Math.max(node.scrollHeight, node.clientHeight);
+
+        // If the element is bigger than the viewport, then we got our scroll container
+        if (elHeight > viewPortHeight) {
+          largestNode = node;
+          break;
+        }
+      }
+
+      if (node.childNodes.length) {
+        largestFirstNode(node.childNodes);
+      }
+    }
+
+    // If the largestNode is the body then return the window
+    return (document.body === largestNode || !largestNode) ? window : largestNode;
+  }
 }

--- a/lib/commands/saveFullPageScreen.ts
+++ b/lib/commands/saveFullPageScreen.ts
@@ -28,9 +28,9 @@ export default async function saveFullPageScreen(
   const disableCSSAnimation: boolean = 'disableCSSAnimation' in saveFullPageOptions.method
     ? saveFullPageOptions.method.disableCSSAnimation
     : saveFullPageOptions.wic.disableCSSAnimation;
-  const hideScrollBars: boolean = 'hideScrollBars' in saveFullPageOptions.method
-    ? saveFullPageOptions.method.hideScrollBars
-    : saveFullPageOptions.wic.hideScrollBars;
+  // default this one to false, this will be handled in
+  // taking the screenshots
+  const hideScrollBars: boolean = false;
   const fullPageScrollTimeout: number = 'fullPageScrollTimeout' in saveFullPageOptions.method
     ? saveFullPageOptions.method.fullPageScrollTimeout
     : saveFullPageOptions.wic.fullPageScrollTimeout;

--- a/lib/methods/screenshots.spec.ts
+++ b/lib/methods/screenshots.spec.ts
@@ -1,6 +1,9 @@
 import {getBase64FullPageScreenshotsData} from './screenshots';
 import {FullPageScreenshotDataOptions} from './screenshots.interfaces';
 import {IMAGE_STRING} from '../mocks/mocks';
+import getAndroidStatusAddressToolBarHeight from '../clientSideScripts/getAndroidStatusAddressToolBarHeight';
+import {OFFSETS} from '../helpers/constants';
+import hideScrollBars from '../clientSideScripts/hideScrollbars';
 
 describe('screenshots', () => {
   describe('getBase64FullPageScreenshotsData', () => {
@@ -21,12 +24,17 @@ describe('screenshots', () => {
         hideAfterFirstScroll: [],
       };
       const MOCKED_EXECUTOR = jest.fn()
+        // For await executor(getAndroidStatusAddressToolBarHeight, OFFSETS.ANDROID))
         .mockResolvedValueOnce({statusAddressBar: {height: 56}})
         // THIS NEEDS TO BE FIXED IN THE FUTURE
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
-        .mockResolvedValueOnce(788);
+        .mockResolvedValueOnce(788)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
 
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });
@@ -48,13 +56,21 @@ describe('screenshots', () => {
       // THIS NEEDS TO BE FIXED IN THE FUTURE
       // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
         // THIS NEEDS TO BE FIXED IN THE FUTURE
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
-        .mockResolvedValueOnce(1200);
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
 
       // await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options);
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
@@ -78,13 +94,21 @@ describe('screenshots', () => {
         // THIS NEEDS TO BE FIXED IN THE FUTURE
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
         // THIS NEEDS TO BE FIXED IN THE FUTURE
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
-        .mockResolvedValueOnce(1200);
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
 
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });
@@ -106,24 +130,44 @@ describe('screenshots', () => {
       // THIS NEEDS TO BE FIXED IN THE FUTURE
       // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
-        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
-        .mockResolvedValueOnce(3200)
-        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
-        .mockResolvedValueOnce(3200);
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
 
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });

--- a/lib/methods/screenshots.spec.ts
+++ b/lib/methods/screenshots.spec.ts
@@ -39,6 +39,48 @@ describe('screenshots', () => {
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });
 
+    it('should get hide elements for the Android nativeWebScreenshot fullpage screenshot', async () => {
+      const options: FullPageScreenshotDataOptions = {
+        addressBarShadowPadding: 6,
+        devicePixelRatio: 2,
+        fullPageScrollTimeout: 1,
+        innerHeight: 600,
+        isAndroid: true,
+        isAndroidNativeWebScreenshot: true,
+        isAndroidChromeDriverScreenshot: false,
+        isIos: false,
+        toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [<HTMLElement><unknown>'<div/>'],
+      };
+      const MOCKED_EXECUTOR = jest.fn()
+      // For await executor(getAndroidStatusAddressToolBarHeight, OFFSETS.ANDROID))
+        .mockResolvedValueOnce({statusAddressBar: {height: 56}})
+        // THIS NEEDS TO BE FIXED IN THE FUTURE
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(788)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 2
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(788)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
+        .mockResolvedValueOnce({});
+
+      expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
+    });
+
     it('should get the Android ChromeDriver fullpage screenshot data', async () => {
       const options: FullPageScreenshotDataOptions = {
         addressBarShadowPadding: 6,
@@ -62,7 +104,7 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(1200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
-        // THIS NEEDS TO BE FIXED IN THE FUTURE
+        // RUN 2
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
@@ -70,6 +112,47 @@ describe('screenshots', () => {
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(1200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
+
+      // await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options);
+      expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
+    });
+
+    it('should hide elements for the Android ChromeDriver fullpage screenshot', async () => {
+      const options: FullPageScreenshotDataOptions = {
+        addressBarShadowPadding: 6,
+        devicePixelRatio: 2,
+        fullPageScrollTimeout: 1,
+        innerHeight: 800,
+        isAndroid: true,
+        isAndroidNativeWebScreenshot: false,
+        isAndroidChromeDriverScreenshot: true,
+        isIos: false,
+        toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [<HTMLElement><unknown>'<div/>'],
+      };
+      const MOCKED_EXECUTOR = jest.fn()
+      // THIS NEEDS TO BE FIXED IN THE FUTURE
+      // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 2
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
         .mockResolvedValueOnce({});
 
       // await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options);
@@ -100,6 +183,34 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(1200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
+        // RUN 2
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
+
+      expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
+    });
+
+    it('should hide elements for the iOS fullpage screenshot', async () => {
+      const options: FullPageScreenshotDataOptions = {
+        addressBarShadowPadding: 6,
+        devicePixelRatio: 2,
+        fullPageScrollTimeout: 1,
+        innerHeight: 800,
+        isAndroid: false,
+        isAndroidNativeWebScreenshot: false,
+        isAndroidChromeDriverScreenshot: false,
+        isIos: true,
+        toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [<HTMLElement><unknown>'<div/>'],
+      };
+      const MOCKED_EXECUTOR = jest.fn()
+        .mockResolvedValueOnce({statusAddressBar: {height: 94}})
         // THIS NEEDS TO BE FIXED IN THE FUTURE
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
@@ -108,6 +219,19 @@ describe('screenshots', () => {
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(1200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 2
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(1200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
         .mockResolvedValueOnce({});
 
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
@@ -136,6 +260,7 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(3200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
+        // RUN 2
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
@@ -144,6 +269,7 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(3200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
+        // RUN 3
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
@@ -152,6 +278,7 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(3200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
+        // RUN 4
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
@@ -160,6 +287,7 @@ describe('screenshots', () => {
         .mockResolvedValueOnce(3200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
         .mockResolvedValueOnce({})
+        // RUN 5
         // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
         .mockResolvedValueOnce({})
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
@@ -167,6 +295,73 @@ describe('screenshots', () => {
         // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
         .mockResolvedValueOnce(3200)
         // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({});
+
+      expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
+    });
+
+    it('should hide elements for the desktop browser fullpage screenshot', async () => {
+      const options: FullPageScreenshotDataOptions = {
+        addressBarShadowPadding: 6,
+        devicePixelRatio: 2,
+        fullPageScrollTimeout: 1,
+        innerHeight: 768,
+        isAndroid: false,
+        isAndroidNativeWebScreenshot: false,
+        isAndroidChromeDriverScreenshot: false,
+        isIos: false,
+        toolBarShadowPadding: 6,
+        hideAfterFirstScroll: [<HTMLElement><unknown>'<div/>'],
+      };
+      const MOCKED_EXECUTOR = jest.fn()
+      // THIS NEEDS TO BE FIXED IN THE FUTURE
+      // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 2
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 3
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 4
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // RUN 5
+        // getFullPageScreenshotsDataNativeMobile: For await executor(scrollToPosition, scrollY)
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, true);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(getDocumentScrollHeight)
+        .mockResolvedValueOnce(3200)
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideScrollBars, false);
+        .mockResolvedValueOnce({})
+        // getFullPageScreenshotsDataNativeMobile: For await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
         .mockResolvedValueOnce({});
 
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();

--- a/lib/methods/screenshots.spec.ts
+++ b/lib/methods/screenshots.spec.ts
@@ -172,5 +172,4 @@ describe('screenshots', () => {
       expect(await getBase64FullPageScreenshotsData(MOCKED_TAKESCREENSHOT, MOCKED_EXECUTOR, options)).toMatchSnapshot();
     });
   });
-
 });

--- a/lib/methods/screenshots.ts
+++ b/lib/methods/screenshots.ts
@@ -13,6 +13,7 @@ import {
 } from './screenshots.interfaces';
 import {StatusAddressToolBarHeight} from '../clientSideScripts/statusAddressToolBarHeight.interfaces';
 import hideRemoveElements from '../clientSideScripts/hideRemoveElements';
+import hideScrollBars from '../clientSideScripts/hideScrollbars';
 
 /**
  * Take a full page screenshots for desktop / iOS / Android
@@ -102,9 +103,15 @@ export async function getFullPageScreenshotsDataNativeMobile(
   let screenshotSizeWidth: number;
 
   for (let i = 0; i <= amountOfScrollsArray.length; i++) {
+    // Show scrollbars before scrolling, otherwise we might not be able to scroll
+    await executor(hideScrollBars, false);
+
     // Determine and start scrolling
     const scrollY = iosViewportHeight * i;
     await executor(scrollToPosition, scrollY);
+
+    // Hide scrollbars before taking a screenshot, we don't want them, on the screenshot
+    await executor(hideScrollBars, false);
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
@@ -149,6 +156,9 @@ export async function getFullPageScreenshotsDataNativeMobile(
   if (hideAfterFirstScroll.length > 0) {
     await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
   }
+
+  // Show scrollbars again to the original state
+  await executor(hideScrollBars, false);
 
   return {
     ...calculateDprData({

--- a/lib/methods/screenshots.ts
+++ b/lib/methods/screenshots.ts
@@ -157,9 +157,6 @@ export async function getFullPageScreenshotsDataNativeMobile(
     await executor(hideRemoveElements, {hide: hideAfterFirstScroll, remove: []}, false);
   }
 
-  // Show scrollbars again to the original state
-  await executor(hideScrollBars, false);
-
   return {
     ...calculateDprData({
       fullPageHeight: scrollHeight - addressBarShadowPadding - toolBarShadowPadding,

--- a/lib/methods/screenshots.ts
+++ b/lib/methods/screenshots.ts
@@ -103,15 +103,12 @@ export async function getFullPageScreenshotsDataNativeMobile(
   let screenshotSizeWidth: number;
 
   for (let i = 0; i <= amountOfScrollsArray.length; i++) {
-    // Show scrollbars before scrolling, otherwise we might not be able to scroll
-    await executor(hideScrollBars, false);
-
     // Determine and start scrolling
     const scrollY = iosViewportHeight * i;
     await executor(scrollToPosition, scrollY);
 
     // Hide scrollbars before taking a screenshot, we don't want them, on the screenshot
-    await executor(hideScrollBars, false);
+    await executor(hideScrollBars, true);
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
@@ -150,6 +147,9 @@ export async function getFullPageScreenshotsDataNativeMobile(
       }, devicePixelRatio),
       screenshot,
     });
+
+    // Show scrollbars again
+    await executor(hideScrollBars, false);
   }
 
   // Put back the hidden elements to visible
@@ -190,6 +190,9 @@ export async function getFullPageScreenshotsDataAndroidChromeDriver(
     const scrollY = innerHeight * i;
     await executor(scrollToPosition, scrollY);
 
+    // Hide scrollbars before taking a screenshot, we don't want them, on the screenshot
+    await executor(hideScrollBars, true);
+
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
 
@@ -225,6 +228,9 @@ export async function getFullPageScreenshotsDataAndroidChromeDriver(
       }, devicePixelRatio),
       screenshot,
     });
+
+    // Show the scrollbars again
+    await executor(hideScrollBars, false);
   }
 
   // Put back the hidden elements to visible
@@ -261,6 +267,9 @@ export async function getFullPageScreenshotsDataDesktop(
     // Determine and start scrolling
     const scrollY = innerHeight * i;
     await executor(scrollToPosition, scrollY);
+
+    // Hide scrollbars before taking a screenshot, we don't want them, on the screenshot
+    await executor(hideScrollBars, true);
 
     // Simply wait the amount of time specified for lazy-loading
     await waitFor(fullPageScrollTimeout);
@@ -301,6 +310,9 @@ export async function getFullPageScreenshotsDataDesktop(
       }, devicePixelRatio),
       screenshot,
     });
+
+    // Show scrollbars again
+    await executor(hideScrollBars, false);
   }
 
   // Put back the hidden elements to visible

--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,7 +2226,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2247,12 +2248,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2267,17 +2270,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2394,7 +2400,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2406,6 +2413,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2420,6 +2428,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2427,12 +2436,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2451,6 +2462,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2531,7 +2543,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2543,6 +2556,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2628,7 +2642,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2664,6 +2679,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2683,6 +2699,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2726,12 +2743,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
-      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -92,9 +92,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.11.tgz",
-      "integrity": "sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz",
+      "integrity": "sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"
@@ -113,9 +113,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
+      "version": "10.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+      "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -989,18 +989,19 @@
       }
     },
     "canvas": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.4.1.tgz",
-      "integrity": "sha512-SaFomFqDuuuSTScTHQ7nXc5ea71Ieb8ctvwXjR7vzLsBMfp3euTv2xsTY70zIoC5r4sSQZYXv6tiHiORJ4y1vg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.5.0.tgz",
+      "integrity": "sha512-wwRz2cLMgb9d+rnotOJCoc04Bzj3aJMpWc6JxAD6lP7bYz0ldcn0sKddoZ0vhD5T8HBxrK+XmRDJb68/2VqARw==",
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.11.0"
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.11.0",
+        "simple-get": "^3.0.3"
       },
       "dependencies": {
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },
@@ -1442,7 +1443,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -2194,9 +2194,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -2219,25 +2219,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2247,13 +2251,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2263,37 +2269,43 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2302,25 +2314,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2329,13 +2345,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2351,7 +2369,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2365,13 +2384,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2380,7 +2401,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2389,7 +2411,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2399,19 +2422,22 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2420,13 +2446,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2435,13 +2463,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2451,7 +2481,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2460,7 +2491,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2469,13 +2501,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2486,7 +2520,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2504,7 +2539,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2514,13 +2550,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2530,7 +2568,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2542,19 +2581,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2563,19 +2605,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2585,19 +2630,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2609,7 +2657,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2617,7 +2666,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2632,7 +2682,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2641,43 +2692,50 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2688,7 +2746,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2697,7 +2756,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2706,13 +2766,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2727,13 +2789,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2742,13 +2806,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true,
           "optional": true
         }
@@ -5621,8 +5687,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5738,19 +5803,19 @@
       "dev": true
     },
     "needle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^4.1.0",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5846,17 +5911,18 @@
       "dev": true
     },
     "np": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/np/-/np-5.0.1.tgz",
-      "integrity": "sha512-2TiY5X0hbQEevPV0WjJ4Os0hjt+Ja3P7cDtiAqBU3jSgyT33Uv6P0g8lIkwLzeTaA8KJe9ykpszjB8DOo27m5Q==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/np/-/np-5.0.2.tgz",
+      "integrity": "sha512-LH+cjmoenSP8d8SB15RXcNQHNDihh9o6YLP3I/bmnetgxG18RmWPdFdOxzTyHcOfFPpFB9aylypwUx5PfoMxwA==",
       "dev": true,
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
         "any-observable": "^0.3.0",
         "async-exit-hook": "^2.0.1",
         "chalk": "^2.3.0",
-        "cosmiconfig": "^5.1.0",
+        "cosmiconfig": "^5.2.1",
         "del": "^4.1.0",
+        "escape-string-regexp": "^2.0.0",
         "execa": "^1.0.0",
         "github-url-from-git": "^1.5.0",
         "has-yarn": "^2.1.0",
@@ -5885,6 +5951,58 @@
         "update-notifier": "^2.1.0"
       },
       "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
+          "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
         "log-symbols": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -5894,19 +6012,28 @@
             "chalk": "^2.4.2"
           }
         },
-        "pkg-dir": {
+        "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.1.0.tgz",
-          "integrity": "sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "p-limit": "^2.2.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
           }
         },
         "semver": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+          "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
           "dev": true
         }
       }
@@ -6111,9 +6238,9 @@
       }
     },
     "open": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.2.0.tgz",
-      "integrity": "sha512-Vxf6HJkwrqmvh9UAID3MnMYXntbTxKLOSfOnO7LJdzPf3NE3KQYFNV0/Lcz2VAndbRFil58XVCyh8tiX11fiYw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
+      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -6640,7 +6767,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -6691,9 +6818,9 @@
           }
         },
         "resolve": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -6973,9 +7100,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -7115,6 +7242,21 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
+      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sisteransi": {
       "version": "0.1.1",
@@ -7983,12 +8125,12 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
-      "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
+      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
@@ -8026,9 +8168,9 @@
           }
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -8104,9 +8246,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -30,26 +30,26 @@
   },
   "homepage": "https://github.com/wswebcreation/webdriver-image-comparison#readme",
   "dependencies": {
-    "canvas": "^2.4.1",
+    "canvas": "^2.5.0",
     "chalk": "^2.4.2",
     "fs-extra": "^7.0.1"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
-    "@types/fs-extra": "^5.0.5",
-    "@types/jest": "^24.0.11",
-    "@types/node": "^10.14.4",
+    "@types/fs-extra": "^5.1.0",
+    "@types/jest": "^24.0.13",
+    "@types/node": "^10.14.7",
     "awesome-typescript-loader": "^5.2.1",
     "coveralls": "^3.0.3",
     "husky": "^1.3.1",
     "jest": "^23.6.0",
-    "np": "^5.0.1",
+    "np": "^5.0.2",
     "rimraf": "^2.6.3",
     "source-map-loader": "^0.2.4",
     "ts-jest": "^23.10.5",
-    "tslint": "^5.15.0",
+    "tslint": "^5.16.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.4.3",
+    "typescript": "^3.4.5",
     "validate-commit-msg": "^2.14.0",
     "vrsource-tslint-rules": "^6.0.0"
   }


### PR DESCRIPTION
- in some cases the default `document.body.scrollHeight` is not sufficient, there can be other factors that influence determining the height of the page
- for full page screenshots the scollbars only need to be hidden after a scroll, bot before. This might block scrolling in some situations
- in some cases the scroll can't be done on the window, it need to be done on the largest element.
- add tests and increase coverage
- fix to add `overflow` to the `body` instead of the `html` element
- update dependencies