### PR TITLE
Update base.ts to accept functions for folder name

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -18,11 +18,21 @@ The padding that needs to be added to the address bar on iOS and Android to do a
 If no baseline image is found during the comparison the image is automatically copied to the baseline folder when this is set to `true`
 
 ### `baselineFolder`
-- **Type:** `string`
+- **Type:** `any`
 - **Mandatory:** No
 - **Default:** `./wic/baseline/`
 
-The directory that will hold all the baseline images that are used to during the comparison.
+The directory that will hold all the baseline images that are used to during the comparison. If not set, the default value will be used. A function that accepts an option object can also be used to set the baselineFolder value:
+```
+  getFolder = type = options => {
+    const testFolder = path.dirname(options.specs[0]);
+    return path.join(testFolder, 'snapshots', type);
+  };
+
+  {
+    baselineFolder: getFolder(options)
+  }
+```
 
 ### `clearRuntimeFolder`
 - **Type:** `boolean`
@@ -90,11 +100,22 @@ Hide scrollbars in the application. If set to true all scrollbars will be disabl
 Save the images per instance in a separate folder so for example all Chrome screenshots will be saved in a chrome folder like `desktop_chrome`.
 
 ### `screenshotPath`
-- **Type:** `string`
+- **Type:** `any`
 - **Default:** `.tmp/`
 - **Mandatory:** no
 
-The directory that will hold all the actual / difference screenshots
+The directory that will hold all the actual / difference screenshots. If not set, the default value will be used. A function that ac
+cepts an option object can also be used to set the screenshotPath value:
+```
+  getFolder = type = options => {
+    const testFolder = path.dirname(options.specs[0]);
+    return path.join(testFolder, 'snapshots', type);
+  };
+
+  {
+    screenshotPath: getFolder(options)
+  }
+```
 
 ### `toolBarShadowPadding`
 - **Type:** `number`

--- a/lib/base.interface.ts
+++ b/lib/base.interface.ts
@@ -1,5 +1,5 @@
 export interface Folders {
   actualFolder: string;   // The actual folder where the current screenshots need to be saved
-  baselineFolder: string; // The baseline folder where the baseline screenshots can be found
+  baselineFolder: any; // The baseline folder where the baseline screenshots can be found
   diffFolder: string;     // The diff folder where the differences are saved
 }

--- a/lib/base.spec.ts
+++ b/lib/base.spec.ts
@@ -13,6 +13,23 @@ describe('BaseClass', () => {
     expect(instance.folders.diffFolder).toBe('../my_folder/screenshots/diff');
   });
 
+  it('should be able to create baselineFolder with a function', () => {
+    const options = {
+      baseline: './subfolder//../baseline',
+      screenshot: './../my_folder//screenshots'
+    };
+    const setPath = (folderPath: any) => {
+      return folderPath;
+    };
+    const instance = new BaseClass({
+      baselineFolder: setPath(options.baseline),
+      screenshotPath: setPath(options.screenshot)
+    });
+    expect(instance.folders.actualFolder).toBe('../my_folder/screenshots/actual');
+    expect(instance.folders.baselineFolder).toBe('baseline');
+    expect(instance.folders.diffFolder).toBe('../my_folder/screenshots/diff');
+  });  
+
   it('should be able to create BaseClass with default options', () => {
     const instance = new BaseClass({});
     expect(instance.folders.actualFolder).toBe('.tmp/actual');

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -13,8 +13,20 @@ export default class BaseClass {
     // determine default options
     this.defaultOptions = defaultOptions(options);
 
-    const baselineFolder = normalize(options.baselineFolder || FOLDERS.DEFAULT.BASE);
-    const baseFolder = normalize(options.screenshotPath || FOLDERS.DEFAULT.SCREENSHOTS);
+    let baselineFolder;
+    let baseFolder;
+
+    if (typeof options.baselineFolder === 'function') {
+      baselineFolder = options.baselineFolder(options);
+    } else {
+      baselineFolder = normalize(options.baselineFolder || FOLDERS.DEFAULT.BASE);
+    }
+
+    if (typeof options.screenshotPath === 'function') {
+      baseFolder = options.screenshotPath(options);
+    } else {
+      baseFolder = normalize(options.screenshotPath || FOLDERS.DEFAULT.SCREENSHOTS);
+    }
 
     this.folders = {
       actualFolder: join(baseFolder, FOLDERS.ACTUAL),

--- a/lib/helpers/options.interface.ts
+++ b/lib/helpers/options.interface.ts
@@ -7,7 +7,7 @@ export interface ClassOptions{
   // If no baseline image is found during the comparison the image is automatically copied to the baseline folder when this is set to `true`
   autoSaveBaseline?: boolean;
   // The directory that will hold all the baseline images that are used to during the comparison
-  baselineFolder?: string;
+  baselineFolder?: any;
   // Delete runtime folder (actual & diff) on initialisation
   clearRuntimeFolder?: boolean;
   // Enable extra console logging or always saving the diff images during comparison
@@ -17,7 +17,7 @@ export interface ClassOptions{
   // Save the images per instance in a separate folder.
   savePerInstance?: boolean;
   // The directory that will hold all the actual / difference screenshots
-  screenshotPath?: string;
+  screenshotPath?: any;
   // The padding that needs to be added to the toolbar bar on iOS and Android to do a proper cutout of the the viewport.
   toolBarShadowPadding?: number;
 

--- a/lib/methods/images.interfaces.ts
+++ b/lib/methods/images.interfaces.ts
@@ -93,7 +93,7 @@ export interface ImageCompareFolderOptions {
   // The actual folder
   actualFolder: string;
   // The baseline folder
-  baselineFolder: string;
+  baselineFolder: any;
   // The name of the browser
   browserName: string;
   // The name of the device


### PR DESCRIPTION
- allow baselineFolder to be a string or function that is passed an
options object
- allow screenshotPath to be a string or function that is passed an
options object

All of our tests aren't located in the same folder. The tests are bundled inside packages along with the source code for each of our components. Our use case is saving the screenshots under the same folder as our tests. 