### PR TITLE
Update getAndroidStatusAddressToolBarHeight.ts for Android 9

### DIFF
--- a/lib/clientSideScripts/getAndroidStatusAddressToolBarHeight.ts
+++ b/lib/clientSideScripts/getAndroidStatusAddressToolBarHeight.ts
@@ -10,7 +10,7 @@ export default function getAndroidStatusAddressToolBarHeight(
   // Determine version for the right offsets
   const {height, width} = window.screen;
   const {innerHeight} = window;
-  const match = (navigator.appVersion).match(/Android (\d+).(\d+).?(\d+)?/);
+  const match = (navigator.appVersion).match(/Android (\d+).?(\d+)?.?(\d+)?/);
   const majorVersion = parseInt(match[1], 10);
   const versionOffsets = androidOffsets[majorVersion];
   const statusAddressBarHeight = versionOffsets.STATUS_BAR + versionOffsets.ADDRESS_BAR;


### PR DESCRIPTION
For Android 9 there is only a major version in `navigator.appVersion`
![Screen Shot 2019-10-02 at 2 32 06 PM](https://user-images.githubusercontent.com/6209204/66071792-c8f9b400-e521-11e9-8085-424624e27fa4.png)


Match updated to work with Android 9
![Screen Shot 2019-10-02 at 2 31 56 PM](https://user-images.githubusercontent.com/6209204/66071720-a6679b00-e521-11e9-8257-fa9b173c660f.png)
