### PR TITLE
When taking full page screenshot: Use actual screenshot height 

### DIFF
--- a/lib/methods/screenshots.ts
+++ b/lib/methods/screenshots.ts
@@ -254,6 +254,7 @@ export async function getFullPageScreenshotsDataDesktop(
 ): Promise<FullPageScreenshotsData> {
   const viewportScreenshots = [];
   const {devicePixelRatio, fullPageScrollTimeout, hideAfterFirstScroll, innerHeight} = options;
+  let actualInnerHeight = innerHeight;
 
   // Start with an empty array, during the scroll it will be filled because a page could also have a lazy loading
   const amountOfScrollsArray = [];
@@ -262,7 +263,7 @@ export async function getFullPageScreenshotsDataDesktop(
 
   for (let i = 0; i <= amountOfScrollsArray.length; i++) {
     // Determine and start scrolling
-    const scrollY = innerHeight * i;
+    const scrollY = actualInnerHeight * i;
     await executor(scrollToPosition, scrollY);
 
     // Simply wait the amount of time specified for lazy-loading
@@ -277,10 +278,20 @@ export async function getFullPageScreenshotsDataDesktop(
     const screenshot = await takeBase64Screenshot(takeScreenshot);
     screenshotSize = getScreenshotSize(screenshot, devicePixelRatio);
 
+    // The actual screenshot size might be slightly different than the inner height
+    // In that case, use the screenshot size instead of the innerHeight
+    if (i === 0 && screenshotSize.height !== actualInnerHeight) {
+      if (Math.round(screenshotSize.height) === actualInnerHeight) {
+        actualInnerHeight = screenshotSize.height;
+      }
+      // No else, because some drivers take a full page screenshot, e.g. FireFox,
+      // and SafariDriver for IE11
+    }
+
     // Determine scroll height and check if we need to scroll again
     scrollHeight = await executor(getDocumentScrollHeight);
 
-    if (((scrollY + innerHeight) < scrollHeight && screenshotSize.height === innerHeight)) {
+    if (((scrollY + actualInnerHeight) < scrollHeight && screenshotSize.height === actualInnerHeight)) {
       amountOfScrollsArray.push(amountOfScrollsArray.length);
     }
     // There is no else, Lazy load and large screenshots,
@@ -288,10 +299,10 @@ export async function getFullPageScreenshotsDataDesktop(
 
     // The height of the image of the last 1 could be different
     const imageHeight: number = amountOfScrollsArray.length === i
-      ? scrollHeight - (innerHeight * viewportScreenshots.length)
+      ? scrollHeight - (actualInnerHeight * viewportScreenshots.length)
       : screenshotSize.height;
     // The starting position for cropping could be different for the last image (0 means no cropping)
-    const imageYPosition = (amountOfScrollsArray.length === i && amountOfScrollsArray.length !== 0) ? innerHeight - imageHeight : 0;
+    const imageYPosition = (amountOfScrollsArray.length === i && amountOfScrollsArray.length !== 0) ? actualInnerHeight - imageHeight : 0;
 
     // Store all the screenshot data in the screenshot object
     viewportScreenshots.push({


### PR DESCRIPTION
instead of innerHeight, but only if they the difference is <1.

Throw an error if the difference is greater than that because it's guaranteed to generate invalid images.

Fixes https://github.com/wswebcreation/protractor-image-comparison/issues/78