### PR TITLE
New feature: Adding scaling images functionality

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -483,3 +483,11 @@ Allowable value of misMatchPercentage that prevents saving image with difference
 	
 Comparing large images can lead to performance issues.
 When providing a number for the amount of pixels here (higher then 0), the comparison algorithm skips pixels when the image width or height is larger than `largeImageThreshold` pixels.
+
+### `scaleImagesToSameSize`
+- **Type:** `boolean`
+- **Default:** `false`
+- **Mandatory:** no
+- **Remark:** *Can also be used for `checkElement`, `checkScreen()` and `checkFullPageScreen()`. It will override the plugin setting*
+
+Scales 2 images to same size before execution of comparison. Highly recommended to enable `ignoreAntialiasing` and ignoreAlpha

--- a/lib/commands/check.interfaces.ts
+++ b/lib/commands/check.interfaces.ts
@@ -23,4 +23,6 @@ export interface CheckMethodOptions {
   returnAllCompareData?: boolean;
   // Allowable value of misMatchPercentage that prevents saving image with
   saveAboveTolerance?: number;
+  //Scale images to same size before comparison
+  scaleImagesToSameSize?:boolean;
 }

--- a/lib/helpers/__snapshots__/options.spec.ts.snap
+++ b/lib/helpers/__snapshots__/options.spec.ts.snap
@@ -16,6 +16,7 @@ Object {
     "rawMisMatchPercentage": false,
     "returnAllCompareData": false,
     "saveAboveTolerance": 0,
+    "scaleImagesToSameSize": false,
   },
   "debug": false,
   "disableCSSAnimation": false,
@@ -43,6 +44,7 @@ Object {
     "rawMisMatchPercentage": true,
     "returnAllCompareData": true,
     "saveAboveTolerance": 12,
+    "scaleImagesToSameSize": true,
   },
   "debug": true,
   "disableCSSAnimation": true,
@@ -74,6 +76,7 @@ Object {
   "rawMisMatchPercentage": true,
   "returnAllCompareData": true,
   "saveAboveTolerance": 12,
+  "scaleImagesToSameSize": true,
 }
 `;
 
@@ -99,5 +102,6 @@ Object {
   "rawMisMatchPercentage": true,
   "returnAllCompareData": true,
   "saveAboveTolerance": 12,
+  "scaleImagesToSameSize": true,
 }
 `;

--- a/lib/helpers/options.interface.ts
+++ b/lib/helpers/options.interface.ts
@@ -55,6 +55,8 @@ export interface ClassOptions{
   returnAllCompareData?: boolean;
   // Allowable value of misMatchPercentage that prevents saving image with differences
   saveAboveTolerance?: number;
+  //Scale images to same size before comparison
+  scaleImagesToSameSize?:boolean;
 }
 
 export interface DefaultOptions {
@@ -82,4 +84,5 @@ interface CompareOptions {
   rawMisMatchPercentage: boolean;
   returnAllCompareData: boolean;
   saveAboveTolerance: number;
+  scaleImagesToSameSize:boolean;
 }

--- a/lib/helpers/options.spec.ts
+++ b/lib/helpers/options.spec.ts
@@ -2,14 +2,14 @@ import {defaultOptions, methodCompareOptions, screenMethodCompareOptions} from '
 import {ClassOptions} from './options.interface';
 import {ScreenMethodImageCompareCompareOptions} from '../methods/images.interfaces';
 
-describe('options', ()=>{
-  describe('defaultOptions', ()=>{
-    it('should return the default options when no options are provided', ()=>{
+describe('options', () => {
+  describe('defaultOptions', () => {
+    it('should return the default options when no options are provided', () => {
       expect(defaultOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', ()=>{
-      const options:ClassOptions = {
+    it('should return the provided options when options are provided', () => {
+      const options: ClassOptions = {
         addressBarShadowPadding: 1,
         autoSaveBaseline: true,
         debug: true,
@@ -29,18 +29,19 @@ describe('options', ()=>{
         rawMisMatchPercentage: true,
         returnAllCompareData: true,
         saveAboveTolerance: 12,
+        scaleImagesToSameSize: false
       };
 
       expect(defaultOptions(options)).toMatchSnapshot();
     });
   });
 
-  describe('methodCompareOptions', ()=>{
-    it('should not return the method options when no options are provided', ()=>{
+  describe('methodCompareOptions', () => {
+    it('should not return the method options when no options are provided', () => {
       expect(methodCompareOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', ()=>{
+    it('should return the provided options when options are provided', () => {
       const options = {
         blockOut: [{height: 1, width: 2, x: 3, y: 4}],
         ignoreAlpha: true,
@@ -51,19 +52,20 @@ describe('options', ()=>{
         rawMisMatchPercentage: true,
         returnAllCompareData: true,
         saveAboveTolerance: 12,
+        scaleImagesToSameSize: true
       };
 
       expect(methodCompareOptions(options)).toMatchSnapshot();
     });
   });
 
-  describe('screenMethodCompareOptions', ()=>{
-    it('should not return the screen method options when no options are provided', ()=>{
+  describe('screenMethodCompareOptions', () => {
+    it('should not return the screen method options when no options are provided', () => {
       expect(screenMethodCompareOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', ()=>{
-      const options:ScreenMethodImageCompareCompareOptions = {
+    it('should return the provided options when options are provided', () => {
+      const options: ScreenMethodImageCompareCompareOptions = {
         blockOutStatusBar: false,
         blockOutToolBar: false,
         blockOut: [{height: 1, width: 2, x: 3, y: 4}],
@@ -75,6 +77,7 @@ describe('options', ()=>{
         rawMisMatchPercentage: true,
         returnAllCompareData: true,
         saveAboveTolerance: 12,
+        scaleImagesToSameSize: true
       };
 
       expect(screenMethodCompareOptions(options)).toMatchSnapshot();

--- a/lib/helpers/options.spec.ts
+++ b/lib/helpers/options.spec.ts
@@ -2,14 +2,14 @@ import {defaultOptions, methodCompareOptions, screenMethodCompareOptions} from '
 import {ClassOptions} from './options.interface';
 import {ScreenMethodImageCompareCompareOptions} from '../methods/images.interfaces';
 
-describe('options', () => {
-  describe('defaultOptions', () => {
-    it('should return the default options when no options are provided', () => {
+describe('options', ()=>{
+  describe('defaultOptions', ()=>{
+    it('should return the default options when no options are provided', ()=>{
       expect(defaultOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', () => {
-      const options: ClassOptions = {
+    it('should return the provided options when options are provided', ()=>{
+      const options:ClassOptions = {
         addressBarShadowPadding: 1,
         autoSaveBaseline: true,
         debug: true,
@@ -29,19 +29,19 @@ describe('options', () => {
         rawMisMatchPercentage: true,
         returnAllCompareData: true,
         saveAboveTolerance: 12,
-        scaleImagesToSameSize: false
+        scaleImagesToSameSize: true
       };
 
       expect(defaultOptions(options)).toMatchSnapshot();
     });
   });
 
-  describe('methodCompareOptions', () => {
-    it('should not return the method options when no options are provided', () => {
+  describe('methodCompareOptions', ()=>{
+    it('should not return the method options when no options are provided', ()=>{
       expect(methodCompareOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', () => {
+    it('should return the provided options when options are provided', ()=>{
       const options = {
         blockOut: [{height: 1, width: 2, x: 3, y: 4}],
         ignoreAlpha: true,
@@ -52,20 +52,20 @@ describe('options', () => {
         rawMisMatchPercentage: true,
         returnAllCompareData: true,
         saveAboveTolerance: 12,
-        scaleImagesToSameSize: true
+        scaleImagesToSameSize: true,
       };
 
       expect(methodCompareOptions(options)).toMatchSnapshot();
     });
   });
 
-  describe('screenMethodCompareOptions', () => {
-    it('should not return the screen method options when no options are provided', () => {
+  describe('screenMethodCompareOptions', ()=>{
+    it('should not return the screen method options when no options are provided', ()=>{
       expect(screenMethodCompareOptions({})).toMatchSnapshot();
     });
 
-    it('should return the provided options when options are provided', () => {
-      const options: ScreenMethodImageCompareCompareOptions = {
+    it('should return the provided options when options are provided', ()=>{
+      const options:ScreenMethodImageCompareCompareOptions = {
         blockOutStatusBar: false,
         blockOutToolBar: false,
         blockOut: [{height: 1, width: 2, x: 3, y: 4}],

--- a/lib/helpers/options.ts
+++ b/lib/helpers/options.ts
@@ -42,6 +42,7 @@ export function defaultOptions(options: ClassOptions): DefaultOptions {
       rawMisMatchPercentage: options.rawMisMatchPercentage || false,
       returnAllCompareData: options.returnAllCompareData || false,
       saveAboveTolerance: options.saveAboveTolerance || 0,
+      scaleImagesToSameSize: options.scaleImagesToSameSize || false
     },
   };
 }
@@ -71,5 +72,6 @@ export function methodCompareOptions(options: any): MethodImageCompareCompareOpt
     ...('rawMisMatchPercentage' in options ? {rawMisMatchPercentage: options.rawMisMatchPercentage} : {}),
     ...('returnAllCompareData' in options ? {returnAllCompareData: options.returnAllCompareData} : {}),
     ...('saveAboveTolerance' in options ? {saveAboveTolerance: options.saveAboveTolerance} : {}),
+    ...('scaleImagesToSameSize' in options ? {scaleImagesToSameSize: options.scaleImagesToSameSize} : {}),
   };
 }

--- a/lib/methods/images.interfaces.ts
+++ b/lib/methods/images.interfaces.ts
@@ -85,6 +85,8 @@ export interface MethodImageCompareCompareOptions {
   returnAllCompareData?: boolean;
   // Allowable value of misMatchPercentage that prevents saving image with differences
   saveAboveTolerance?: number;
+  //Scale images to same size before comparison
+  scaleImagesToSameSize?:boolean;
 }
 
 export interface ImageCompareFolderOptions {
@@ -127,6 +129,7 @@ export interface CompareOptions {
   output?: {
     ignoredBoxes?: IgnoreBoxes[]
   };
+  scaleToSameSize? : boolean;
 }
 
 export interface IgnoreBoxes {

--- a/lib/methods/images.ts
+++ b/lib/methods/images.ts
@@ -135,6 +135,7 @@ export async function executeImageCompare(
   const compareOptions: CompareOptions = {
     ignore,
     ...(ignoredBoxes.length > 0 ? {output: {ignoredBoxes}} : {}),
+    scaleToSameSize: imageCompareOptions.scaleImagesToSameSize,
   };
 
   // 5.		Execute the compare and retrieve the data

--- a/lib/resemble/compareImages.ts
+++ b/lib/resemble/compareImages.ts
@@ -6,7 +6,15 @@ import {CompareData} from './compare.interfaces';
 
 export default async function compareImages(image1: Buffer, image2: Buffer, options: CompareOptions):Promise<CompareData> {
   return new Promise((resolve, reject) => {
-    resemble.compare(image1, image2, options, (err: any, data: any) => {
+
+    //Resemble.js implemented in the way that scales 2nd images to the size of 1st.
+    //Experimentally proven that downscaling images produces more accurate result than upscaling
+    let {imageToCompare1, imageToCompare2} = options.scaleToSameSize && image1.length > image2.length? {
+      imageToCompare1: image2,
+      imageToCompare2: image1
+    } : {imageToCompare1: image1, imageToCompare2: image2};
+
+    resemble.compare(imageToCompare1, imageToCompare2, options, (err: any, data: any) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
At the moment webdriver-image-comparison saves images and perform image comparison as is, not taking into account dpr of devices screenshots were taken from. As a result, when running tests on devices with different dpr compared to ones baseline screenshot was taken from, you often get false negative. I.e. images taken from macbook with retina display compared to image taken from regular display produce following result: (mismatch percentage is 77%)

![image](https://user-images.githubusercontent.com/5863985/69630242-18092480-104d-11ea-9e60-06f9152df36c.png)

Current PR tries to address this issue via functionality of resemble.js scaleToSameSize
In order to enable such functionality one needs to add flag `scaleToSameSize : true` either to plugin configuration or directly the the method of comparing images, e.g. `compareElements`

Comparison result after applying rescaling: (mismatch percentage is 2%)
![image](https://user-images.githubusercontent.com/5863985/69634979-ada7b280-1053-11ea-8c90-a994b738b1fb.png)
