### PR TITLE
Prevent tsconfig.json from being published which causes a problem with the 'includes' field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ localBaseline/
 docs/
 lib/
 .eslintcache
+tsconfig.json


### PR DESCRIPTION
Fixes a TS compiler problem with the published package, since some times it tries to scan all tsconfig.json files in node_modules to build up the types graph. VSCode in my case gave me the hint:

```
No inputs were found in config file '/Users/[...]/dev/[...]/node_modules/webdriver-image-comparison/tsconfig.json'.

Specified 'include' paths were '[\"lib/**/*\"]' and 'exclude' paths were '[\"./build\"]'.".
```