### PR TITLE
Fix TS types for ResizeDimensions

### DIFF
--- a/lib/helpers/constants.ts
+++ b/lib/helpers/constants.ts
@@ -1,4 +1,5 @@
 import { IosOffsets } from './constants.interfaces';
+import { ResizeDimensions } from '../methods/images.interfaces';
 
 export const DEFAULT_FORMAT_STRING = '{tag}-{browserName}-{width}x{height}-dpr-{dpr}';
 export const PLATFORMS = {
@@ -20,7 +21,7 @@ export const DEFAULT_SHADOW = {
 };
 export const DESKTOP = 'desktop';
 export const CUSTOM_CSS_ID = 'pic-css';
-export const DEFAULT_RESIZE_DIMENSIONS = {
+export const DEFAULT_RESIZE_DIMENSIONS: Required<ResizeDimensions> = {
   top: 0,
   right: 0,
   bottom: 0,

--- a/lib/methods/images.interfaces.ts
+++ b/lib/methods/images.interfaces.ts
@@ -3,13 +3,13 @@ import { LogLevel } from '../helpers/options.interface';
 
 export interface ResizeDimensions {
   // The bottom margin
-  bottom: number;
+  bottom?: number;
   // The left margin
-  left: number;
+  left?: number;
   // The right margin
-  right: number;
+  right?: number;
   // The top margin
-  top: number;
+  top?: number;
 }
 
 export interface ImageCompareOptions {


### PR DESCRIPTION
The `ResizeDimensions` have a default value, so the TypeScript types should not throw an error if some properties aren't defined.